### PR TITLE
Fix `onLoadMore` is triggered even when list is not visible

### DIFF
--- a/demo/src/InfiniteList.js
+++ b/demo/src/InfiniteList.js
@@ -21,6 +21,7 @@ const ARRAY_SIZE = 20;
 const RESPONSE_TIME = 1000;
 
 function loadItems(prevArray = [], startCursor = 0) {
+  console.log('loadItems', startCursor);
   return new Promise(resolve => {
     setTimeout(() => {
       let newArray = prevArray;

--- a/demo/src/index.js
+++ b/demo/src/index.js
@@ -27,6 +27,9 @@ function Demo() {
       <ListContainer scrollable={scrollParent}>
         <InfiniteList scrollContainer={scrollParent ? 'parent' : 'window'} />
       </ListContainer>
+        <div style={{height: 600, backgroundColor: 'yellow'}}>
+            footer
+        </div>
     </React.Fragment>
   );
 }


### PR DESCRIPTION
Problem.

When list is not visible on the page the `onLoadMore` is constantly triggered.
Bug exists for lists with `window` as `parent`

![ezgif com-video-to-gif (3)](https://user-images.githubusercontent.com/895071/88393637-472f8b80-cdbe-11ea-9e56-edd34b778fde.gif)


Steps to reproduce.

Comment out the following lines
```
if (!isListInView()) {
   return;
}
```
Run the demo from this PR, reduce browser window, so only yellow footer is visible.
You will se in console that `onLoadMore` is being triggered for ever


Fix.

Trigger `onLoadMore` only if list is in the view.

![ezgif com-video-to-gif (4)](https://user-images.githubusercontent.com/895071/88393648-4d256c80-cdbe-11ea-970b-97aecaab3dba.gif)
