### PR TITLE
feat: add `mode` options to provide scroll event

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 node_modules
 .cache
 dist
+yarn.lock

--- a/example/InfiniteList.tsx
+++ b/example/InfiniteList.tsx
@@ -24,7 +24,7 @@ const ListItem = styled.li`
   margin: 4px;
 `;
 
-const ARRAY_SIZE = 20;
+const ARRAY_SIZE = 3;
 const RESPONSE_TIME = 1000;
 
 function loadItems(prevArray: Item[] = [], startCursor = 0): Promise<Item[]> {
@@ -59,6 +59,12 @@ function InfiniteList({
       setItems(newArray);
     });
   }
+
+  // React.useEffect(() => {
+  //   if (mode === InfiniteScrollMode.SCROLL_EVENT) {
+  //     handleLoadMore();
+  //   }
+  // }, [mode]);
 
   const infiniteRef = useInfiniteScroll<HTMLUListElement>({
     loading,

--- a/example/InfiniteList.tsx
+++ b/example/InfiniteList.tsx
@@ -1,5 +1,8 @@
 import * as React from 'react';
-import useInfiniteScroll from '../src';
+import useInfiniteScroll, {
+  InfiniteScrollMode,
+  UseInfiniteScrollArgs,
+} from '../src';
 import styled from 'styled-components';
 
 interface Item {
@@ -25,7 +28,7 @@ const ARRAY_SIZE = 20;
 const RESPONSE_TIME = 1000;
 
 function loadItems(prevArray: Item[] = [], startCursor = 0): Promise<Item[]> {
-  return new Promise(resolve => {
+  return new Promise((resolve) => {
     setTimeout(() => {
       let newArray = prevArray;
 
@@ -42,13 +45,16 @@ function loadItems(prevArray: Item[] = [], startCursor = 0): Promise<Item[]> {
   });
 }
 
-function InfiniteList({ scrollContainer }) {
+function InfiniteList({
+  scrollContainer,
+  mode = InfiniteScrollMode.INTERVAL,
+}: Partial<UseInfiniteScrollArgs>) {
   const [loading, setLoading] = React.useState(false);
   const [items, setItems] = React.useState<Item[]>([]);
 
   function handleLoadMore() {
     setLoading(true);
-    loadItems(items, items.length).then(newArray => {
+    loadItems(items, items.length).then((newArray) => {
       setLoading(false);
       setItems(newArray);
     });
@@ -61,11 +67,12 @@ function InfiniteList({ scrollContainer }) {
     hasNextPage: true,
     onLoadMore: handleLoadMore,
     scrollContainer,
+    mode,
   });
 
   return (
     <List ref={infiniteRef}>
-      {items.map(item => (
+      {items.map((item) => (
         <ListItem key={item.key}>{item.value}</ListItem>
       ))}
       {loading && <ListItem>Loading...</ListItem>}

--- a/example/index.tsx
+++ b/example/index.tsx
@@ -3,14 +3,15 @@ import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import InfiniteList from './InfiniteList';
 import styled from 'styled-components';
+import { InfiniteScrollMode } from '../src';
 
 interface ListContainerProps {
   scrollable: boolean;
 }
 
 const ListContainer = styled.div<ListContainerProps>`
-  max-height: ${props => (props.scrollable ? '600px' : 'auto')};
-  max-width: ${props => (props.scrollable ? '600px' : 'auto')};
+  max-height: ${(props) => (props.scrollable ? '600px' : 'auto')};
+  max-width: ${(props) => (props.scrollable ? '600px' : 'auto')};
   overflow: auto;
   background-color: #e4e4e4;
 `;
@@ -22,20 +23,36 @@ const Footer = styled.div`
 
 function App() {
   const [scrollParent, setScrollParent] = React.useState(false);
+  const [scrollMode, setScrollMode] = React.useState(false);
 
   function handleChange(e) {
     const checked = e.target.checked;
     setScrollParent(checked);
   }
-
+  function handleModeChange(e) {
+    const checked = e.target.checked;
+    setScrollMode(checked);
+  }
   return (
     <React.Fragment>
       <h1>Infinite List</h1>
       <h3>Created by using “react-infinite-scroll-hook”</h3>
       <input type="checkbox" checked={scrollParent} onChange={handleChange} />
       Scrollable Parent
+      <input type="checkbox" checked={scrollMode} onChange={handleModeChange} />
+      ScrollEvent Mode
       <ListContainer scrollable={scrollParent}>
-        <InfiniteList scrollContainer={scrollParent ? 'parent' : 'window'} />
+        {
+          <InfiniteList
+            key={'scrollEvent'}
+            scrollContainer={scrollParent ? 'parent' : 'window'}
+            mode={
+              scrollMode
+                ? InfiniteScrollMode.SCROLL_EVENT
+                : InfiniteScrollMode.INTERVAL
+            }
+          />
+        }
       </ListContainer>
       <Footer>Footer</Footer>
     </React.Fragment>

--- a/example/index.tsx
+++ b/example/index.tsx
@@ -23,7 +23,7 @@ const Footer = styled.div`
 
 function App() {
   const [scrollParent, setScrollParent] = React.useState(false);
-  const [scrollMode, setScrollMode] = React.useState(false);
+  const [scrollMode, setScrollMode] = React.useState(true);
 
   function handleChange(e) {
     const checked = e.target.checked;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1747,6 +1747,12 @@
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
       "dev": true
     },
+    "@types/lodash": {
+      "version": "4.14.158",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.158.tgz",
+      "integrity": "sha512-InCEXJNTv/59yO4VSfuvNrZHt7eeNtWQEgnieIA+mIC+MOWM9arOWG2eQ8Vhk6NbOre6/BidiXhkZYeDY9U35w==",
+      "dev": true
+    },
     "@types/node": {
       "version": "14.0.27",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.27.tgz",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   ],
   "module": "dist/react-infinite-scroll-hook.esm.js",
   "devDependencies": {
+    "@types/lodash": "^4.14.158",
     "@types/react": "^16.9.44",
     "@types/react-dom": "^16.9.8",
     "@typescript-eslint/eslint-plugin": "^3.7.1",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,8 +1,9 @@
 import useInfiniteScroll, {
   UseInfiniteScrollArgs,
   InfiniteScrollContainer,
+  InfiniteScrollMode,
 } from './useInfiniteScroll';
 
-export { UseInfiniteScrollArgs, InfiniteScrollContainer };
+export { UseInfiniteScrollArgs, InfiniteScrollContainer, InfiniteScrollMode };
 
 export default useInfiniteScroll;

--- a/src/useInfiniteScroll.ts
+++ b/src/useInfiniteScroll.ts
@@ -80,7 +80,7 @@ function useInfiniteScroll<T extends HTMLElement>(
   // "updateQuery" twice). Thus we set our own "listen" state which immeadiately turns to "false" on
   // calling "onLoadMore".
   const [listen, setListen] = useState(true);
-
+  const [isFull, setIsFull] = useState(0);
   useEffect(() => {
     if (!loading) {
       setListen(true);
@@ -161,6 +161,8 @@ function useInfiniteScroll<T extends HTMLElement>(
         if (validOffset) {
           setListen(false);
           onLoadMore();
+        } else {
+          setIsFull((val) => val + 1);
         }
       }
     }
@@ -186,18 +188,20 @@ function useInfiniteScroll<T extends HTMLElement>(
     };
   }, [ref.current, props]);
 
-  useEffect(() => {
-    if (isScrollEventMode) {
-      listenBottomOffset();
-    }
-  }, [isScrollEventMode]);
+  // useEffect(() => {
+  //   if (isScrollEventMode) {
+  //     listenBottomOffset();
+  //   }
+  // }, [isScrollEventMode]);
 
   useInterval(
     () => {
       listenBottomOffset();
     },
     // Stop interval when there is no next page.
-    hasNextPage && !isScrollEventMode ? checkInterval : 0,
+    (hasNextPage && !isScrollEventMode) || (isScrollEventMode && isFull < 1)
+      ? checkInterval
+      : 0,
   );
 
   return ref;


### PR DESCRIPTION
Hello, I use scrollEvent mode detect loadmore callback in my project, and it works well in IOS and Android. And how do you think about that ? 😄 We can provide the options depends on user 's need!

By the way, I am sorry for my my fault about my useless PR because I has not seen the v3.0 yet when I commit pulling request. 